### PR TITLE
Dont move the consumer to user space

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,10 +10,9 @@ things configured for you.
 This file will be "composer copied" to your projects bin folder (ie `vendor/bin/message-consumer`). This file receives 
 SNS messages and gives them to `App\Consumer\SnsConsumer`.
 
-#### src/Consumer/SnsConsumer
+#### src/Consumer.php
 
-This file will be copied by Flex to `App\Consumer\SnsConsumer`. This class is responsible to decode the SNS message
-and put it back on the message bus. Feel free to modify this file after your needs. Maybe configure [retry mechanism](http://developer.happyr.com/sns-retry).
+This class is responsible to decode the SNS message and put it back on the message bus. 
 
 #### config/sns-consumer.yaml
 

--- a/bin/message-consumer
+++ b/bin/message-consumer
@@ -21,7 +21,7 @@ lambda(static function (array $event) {
     $container = $kernel->getContainer();
 
     /** @var SnsConsumer $consumer */
-    $consumer = $container->get('app.sns_consumer');
+    $consumer = $container->get(\Bref\MessengerSns\Consumer::class);
 
     foreach ($event['Records'] as $record) {
         if (!isset($record['Sns'])) {

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
     "require": {
         "enqueue/sns": "^0.9.12",
         "sroze/messenger-enqueue-transport": "^0.3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Bref\\MessengerSns\\": "src/"
+        }
     }
 }

--- a/config/sns-consumer.yaml
+++ b/config/sns-consumer.yaml
@@ -1,7 +1,6 @@
 services:
-  app.sns_consumer:
+  Bref\MessengerSns\Consumer:
     public: true
-    class: App\Consumer\SnsConsumer
     arguments:
       - '@messenger.routable_message_bus'
       - '@messenger.default_serializer'

--- a/src/Event/SnsMessageDecodeFailed.php
+++ b/src/Event/SnsMessageDecodeFailed.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\MessengerSns\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+class SnsMessageDecodeFailed
+{
+    use SnsMessageTrait;
+    private $throwable;
+    private $receiverName;
+
+    public function __construct(array $snsEvent, \Throwable $throwable, string $receiverName)
+    {
+        $this->snsEvent = $snsEvent;
+        $this->throwable = $throwable;
+        $this->receiverName = $receiverName;
+    }
+
+    public function getThrowable(): \Throwable
+    {
+        return $this->throwable;
+    }
+
+    public function getReceiverName(): string
+    {
+        return $this->receiverName;
+    }
+}

--- a/src/Event/SnsMessageFailed.php
+++ b/src/Event/SnsMessageFailed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\MessengerSns\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+class SnsMessageFailed extends WorkerMessageFailedEvent
+{
+    use SnsMessageTrait;
+
+    public function __construct(array $snsEvent, Envelope $envelope, string $receiverName, \Throwable $error, bool $willRetry)
+    {
+        $this->snsEvent = $snsEvent;
+
+        parent::__construct($envelope, $receiverName, $error, $willRetry);
+    }
+}

--- a/src/Event/SnsMessageHandled.php
+++ b/src/Event/SnsMessageHandled.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\MessengerSns\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+class SnsMessageHandled extends WorkerMessageHandledEvent
+{
+    use SnsMessageTrait;
+
+    public function __construct(array $snsEvent, Envelope $envelope, string $receiverName)
+    {
+        $this->snsEvent = $snsEvent;
+        parent::__construct($envelope, $receiverName);
+    }
+}

--- a/src/Event/SnsMessageReceived.php
+++ b/src/Event/SnsMessageReceived.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\MessengerSns\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+class SnsMessageReceived extends WorkerMessageReceivedEvent
+{
+    use SnsMessageTrait;
+
+    public function __construct(array $snsEvent, Envelope $envelope, string $receiverName)
+    {
+        $this->snsEvent = $snsEvent;
+        parent::__construct($envelope, $receiverName);
+    }
+}

--- a/src/Event/SnsMessageTrait.php
+++ b/src/Event/SnsMessageTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\MessengerSns\Event;
+
+trait SnsMessageTrait
+{
+    private $snsEvent;
+
+    public function getSnsEvent(): array
+    {
+        return $this->snsEvent;
+    }
+}


### PR DESCRIPTION
This is an alternative approach for the package. Currently we just copy some files to `/src` and let the user handle the implementation. 

With this PR we keep the code in `/vendor` and allow the user to interact with the SNS event using Symfony events. 
Im not sure what I like the most...
